### PR TITLE
Fix a build issue in the legacy FileActions workspace and enable iOS builds

### DIFF
--- a/FileActions.xcworkspace/contents.xcworkspacedata
+++ b/FileActions.xcworkspace/contents.xcworkspacedata
@@ -5,6 +5,6 @@
       location = "group:core/FileActionsCore.xcodeproj">
    </FileRef>
    <FileRef
-      location = "group:/Users/jbmorley/Projects/file-actions/ios/FileActions-iOS.xcodeproj">
+      location = "group:ios/FileActions-iOS.xcodeproj">
    </FileRef>
 </Workspace>

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -21,7 +21,7 @@ xcodebuild \
     clean \
     build \
     CODE_SIGN_IDENTITY="" \
-    CODE_SIGNING_REQUIRED=NO
+    CODE_SIGNING_REQUIRED=NO | xcpretty
 
 # File Actions
 
@@ -32,4 +32,4 @@ xcodebuild \
     clean \
     build \
     CODE_SIGN_IDENTITY="" \
-    CODE_SIGNING_REQUIRED=NO
+    CODE_SIGNING_REQUIRED=NO | xcpretty

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -33,3 +33,21 @@ xcodebuild \
     build \
     CODE_SIGN_IDENTITY="" \
     CODE_SIGNING_REQUIRED=NO | xcpretty
+
+# FileActionsCore iOS
+xcodebuild \
+    -workspace "$FILE_ACTIONS_WORKSPACE_PATH" \
+    -scheme "FileActionsCore iOS" \
+    clean \
+    build \
+    CODE_SIGN_IDENTITY="" \
+    CODE_SIGNING_REQUIRED=NO | xcpretty
+
+# FileActionsCore macOS
+xcodebuild \
+    -workspace "$FILE_ACTIONS_WORKSPACE_PATH" \
+    -scheme "FileActionsCore macOS" \
+    clean \
+    build \
+    CODE_SIGN_IDENTITY="" \
+    CODE_SIGNING_REQUIRED=NO | xcpretty

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -7,14 +7,28 @@ set -x
 SCRIPT_DIRECTORY="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 ROOT_DIRECTORY="${SCRIPT_DIRECTORY}/.."
 
-PROJECT_PATH="${ROOT_DIRECTORY}/document-finder/Fileaway.xcodeproj"
+FILEAWAY_PROJECT_PATH="${ROOT_DIRECTORY}/document-finder/Fileaway.xcodeproj"
+FILE_ACTIONS_WORKSPACE_PATH="${ROOT_DIRECTORY}/FileActions.xcworkspace"
 
 # TODO: Enable test builds if possible using a locally generated signing key.
 
-# macOS
+# Fileaway
+
+# macOS app
 xcodebuild \
-    -project "$PROJECT_PATH" \
+    -project "$FILEAWAY_PROJECT_PATH" \
     -scheme Fileaway \
+    clean \
+    build \
+    CODE_SIGN_IDENTITY="" \
+    CODE_SIGNING_REQUIRED=NO
+
+# File Actions
+
+# iOS app
+xcodebuild \
+    -workspace "$FILE_ACTIONS_WORKSPACE_PATH" \
+    -scheme "File Actions iOS" \
     clean \
     build \
     CODE_SIGN_IDENTITY="" \


### PR DESCRIPTION
It looks like an absolute path found its way into the FileActions workspace meaning that builds wouldn't work unless the source was checked out in a very specific location. This fixes that and adds the FileActions workspace to the GitHub actions builds.