### PR TITLE
Support duplicating rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ Right now the macOS and iOS apps are incredibly divergent having been written wi
 
 ## Changelog
 
+### Version 0.1.1 (macOS)
+
+- Support duplicating rules
+
 ### Version 0.1.0 (macOS)
 
 Initial release with support for a single inbox and archive directories, rules wizard, and simple rule editing.

--- a/ios/Fileaway/State/ComponentState.swift
+++ b/ios/Fileaway/State/ComponentState.swift
@@ -50,7 +50,6 @@ class ComponentState: ObservableObject, Identifiable {
         self.variable = variable
     }
 
-    // TODO: How do we actually copy???
     init(_ component: ComponentState, variable: VariableState?) {
         id = component.id
         value = String(component.value)

--- a/ios/Fileaway/State/TaskState.swift
+++ b/ios/Fileaway/State/TaskState.swift
@@ -82,11 +82,11 @@ class TaskState: ObservableObject, Identifiable, BackChannelable, CustomStringCo
         }
     }
 
-    convenience init(_ task: TaskState) {
-        self.init(id: task.id,
-                  name: String(task.name),
-                  variables: task.variables.map { VariableState($0) },
-                  destination: task.destination.map { ComponentState($0, variable: nil) })
+    convenience init(_ taskState: TaskState) {
+        self.init(id: UUID(),
+                  name: String(taskState.name),
+                  variables: taskState.variables.map { VariableState($0) },
+                  destination: taskState.destination.map { ComponentState($0, variable: nil) })
     }
 
     init(task: Task) {

--- a/ios/Fileaway/State/VariableState.swift
+++ b/ios/Fileaway/State/VariableState.swift
@@ -41,8 +41,9 @@ class VariableState: ObservableObject, Identifiable {
         self.type = variable.type
     }
 
+    // TODO: This should generate a new ID, and there should be explicit setters if we're setting variables.
     public init(_ variable: VariableState) {
-        id = variable.id
+        id = variable.id // TODO: Check why this uses the same id!
         name = String(variable.name)
         type = variable.type
     }

--- a/ios/Fileaway/State/VariableState.swift
+++ b/ios/Fileaway/State/VariableState.swift
@@ -41,13 +41,6 @@ class VariableState: ObservableObject, Identifiable {
         self.type = variable.type
     }
 
-    // TODO: This should generate a new ID, and there should be explicit setters if we're setting variables.
-    public init(_ variable: VariableState) {
-        id = variable.id // TODO: Check why this uses the same id!
-        name = String(variable.name)
-        type = variable.type
-    }
-
     public init(name: String, type: VariableType) {
         self.name = name
         self.type = type

--- a/ios/Fileaway/State/VariableState.swift
+++ b/ios/Fileaway/State/VariableState.swift
@@ -41,6 +41,12 @@ class VariableState: ObservableObject, Identifiable {
         self.type = variable.type
     }
 
+    public init(_ variable: VariableState) {
+        id = variable.id
+        name = String(variable.name)
+        type = variable.type
+    }
+
     public init(name: String, type: VariableType) {
         self.name = name
         self.type = type

--- a/macos/Fileaway-macOS.xcodeproj/project.pbxproj
+++ b/macos/Fileaway-macOS.xcodeproj/project.pbxproj
@@ -73,6 +73,8 @@
 		D8FC5334257BB6D2008FB609 /* MailboxRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FC5333257BB6D2008FB609 /* MailboxRow.swift */; };
 		D8FC5342257BB77C008FB609 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FC5341257BB77C008FB609 /* SettingsView.swift */; };
 		D8FC534A257BB7A4008FB609 /* GeneralSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FC5349257BB7A4008FB609 /* GeneralSettingsView.swift */; };
+		D8FDDA2C261A43B30060D256 /* RightClickObservingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FDDA2B261A43B30060D256 /* RightClickObservingView.swift */; };
+		D8FDDA31261A442B0060D256 /* RightClickableSwiftUIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FDDA30261A442B0060D256 /* RightClickableSwiftUIView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -164,6 +166,8 @@
 		D8FC5333257BB6D2008FB609 /* MailboxRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MailboxRow.swift; sourceTree = "<group>"; };
 		D8FC5341257BB77C008FB609 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		D8FC5349257BB7A4008FB609 /* GeneralSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralSettingsView.swift; sourceTree = "<group>"; };
+		D8FDDA2B261A43B30060D256 /* RightClickObservingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightClickObservingView.swift; sourceTree = "<group>"; };
+		D8FDDA30261A442B0060D256 /* RightClickableSwiftUIView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightClickableSwiftUIView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -237,6 +241,8 @@
 				D8B6D02A257DBAF700C7E472 /* SearchField.swift */,
 				D821E945257AA5FC005D3205 /* Sidebar.swift */,
 				D8D78AA62580DF190088890F /* Legacy.swift */,
+				D8FDDA2B261A43B30060D256 /* RightClickObservingView.swift */,
+				D8FDDA30261A442B0060D256 /* RightClickableSwiftUIView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -542,7 +548,9 @@
 				D8F8BE002586C6B90010432F /* RuleInstance.swift in Sources */,
 				D8E7F9B125999C8800C7409B /* RulesSettingsView.swift in Sources */,
 				D8F8BE22258819860010432F /* StringInstance.swift in Sources */,
+				D8FDDA31261A442B0060D256 /* RightClickableSwiftUIView.swift in Sources */,
 				D8F8BE3225881BC50010432F /* VariableInstance.swift in Sources */,
+				D8FDDA2C261A43B30060D256 /* RightClickObservingView.swift in Sources */,
 				D821E946257AA5FC005D3205 /* Sidebar.swift in Sources */,
 				D8F8BE4125881CEC0010432F /* TrackerInput.swift in Sources */,
 				D8005AC1258276250001BE2C /* Configuration.swift in Sources */,

--- a/macos/Fileaway-macOS.xcodeproj/project.pbxproj
+++ b/macos/Fileaway-macOS.xcodeproj/project.pbxproj
@@ -747,7 +747,7 @@
 				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 5;
+				CURRENT_PROJECT_VERSION = 6;
 				DEVELOPMENT_ASSET_PATHS = "\"Fileaway/Preview Content\"";
 				DEVELOPMENT_TEAM = S4WXAUZQEV;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -758,7 +758,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 0.1.0;
+				MARKETING_VERSION = 0.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = uk.co.inseven.fileaway;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -774,7 +774,7 @@
 				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 5;
+				CURRENT_PROJECT_VERSION = 6;
 				DEVELOPMENT_ASSET_PATHS = "\"Fileaway/Preview Content\"";
 				DEVELOPMENT_TEAM = S4WXAUZQEV;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -785,7 +785,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 0.1.0;
+				MARKETING_VERSION = 0.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = uk.co.inseven.fileaway;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;

--- a/macos/Fileaway/Core/Configuration.swift
+++ b/macos/Fileaway/Core/Configuration.swift
@@ -25,11 +25,6 @@ struct Configuration: Codable {
     let variables: [Variable]
     let destination: [Component]
 
-    init(_ configuration: Configuration) {
-        self.variables = configuration.variables
-        self.destination = configuration.destination
-    }
-
     init(variables: [Variable], destination: [Component]) {
         self.variables = variables
         self.destination = destination

--- a/macos/Fileaway/Core/Configuration.swift
+++ b/macos/Fileaway/Core/Configuration.swift
@@ -25,6 +25,11 @@ struct Configuration: Codable {
     let variables: [Variable]
     let destination: [Component]
 
+    init(_ configuration: Configuration) {
+        self.variables = configuration.variables
+        self.destination = configuration.destination
+    }
+
     init(variables: [Variable], destination: [Component]) {
         self.variables = variables
         self.destination = destination

--- a/macos/Fileaway/Core/RuleSet.swift
+++ b/macos/Fileaway/Core/RuleSet.swift
@@ -93,7 +93,6 @@ class RuleSet: ObservableObject {
      name in the case that the preferred name is not found to be unique. This is intended to match the behaviour of
      duplication in Finder.
      */
-    // TODO: Determine if it's necessary to localize this in the future
     fileprivate func uniqueRuleName(preferredName: String) -> String {
         var name = preferredName
         var index = 2

--- a/macos/Fileaway/Core/RuleState.swift
+++ b/macos/Fileaway/Core/RuleState.swift
@@ -41,20 +41,6 @@ class RuleState: ObservableObject, Identifiable, CustomStringConvertible, Hashab
         self.name
     }
 
-    func establishBackChannel() {
-        variablesBackChannel = BackChannel(value: variables, publisher: $variables).bind {
-            self.objectWillChange.send()
-            DispatchQueue.main.async {
-                for component in self.destination {
-                    component.update()
-                }
-            }
-        }
-        destinationBackChannel = BackChannel(value: destination, publisher: $destination).bind {
-            self.objectWillChange.send()
-        }
-    }
-
     init(id: UUID, rootUrl: URL, name: String, variables: [VariableState], destination: [ComponentState]) {
         self.id = id
         self.rootUrl = rootUrl
@@ -69,15 +55,6 @@ class RuleState: ObservableObject, Identifiable, CustomStringConvertible, Hashab
             component.variable = variable
         }
         self.establishBackChannel()
-    }
-
-    convenience init(_ rule: RuleState, rootUrl: URL) {
-        // TODO: This looks like a copy constructor, but totally isn't.
-        self.init(id: rule.id,
-                  rootUrl: rootUrl,
-                  name: String(rule.name),
-                  variables: rule.variables.map { VariableState($0) },
-                  destination: rule.destination.map { ComponentState($0, variable: nil) })
     }
 
     convenience init(_ rule: RuleState) {
@@ -99,12 +76,18 @@ class RuleState: ObservableObject, Identifiable, CustomStringConvertible, Hashab
         self.establishBackChannel()
     }
 
-    // TODO: Check if this is used
-    init(rootUrl: URL, name: String) {
-        self.rootUrl = rootUrl
-        self.name = name
-        self.variables = []
-        self.destination = []
+    func establishBackChannel() {
+        variablesBackChannel = BackChannel(value: variables, publisher: $variables).bind {
+            self.objectWillChange.send()
+            DispatchQueue.main.async {
+                for component in self.destination {
+                    component.update()
+                }
+            }
+        }
+        destinationBackChannel = BackChannel(value: destination, publisher: $destination).bind {
+            self.objectWillChange.send()
+        }
     }
 
     func remove(component: ComponentState) {

--- a/macos/Fileaway/Core/RuleState.swift
+++ b/macos/Fileaway/Core/RuleState.swift
@@ -72,8 +72,17 @@ class RuleState: ObservableObject, Identifiable, CustomStringConvertible, Hashab
     }
 
     convenience init(_ rule: RuleState, rootUrl: URL) {
+        // TODO: This looks like a copy constructor, but totally isn't.
         self.init(id: rule.id,
                   rootUrl: rootUrl,
+                  name: String(rule.name),
+                  variables: rule.variables.map { VariableState($0) },
+                  destination: rule.destination.map { ComponentState($0, variable: nil) })
+    }
+
+    convenience init(_ rule: RuleState) {
+        self.init(id: UUID(),
+                  rootUrl: rule.rootUrl,
                   name: String(rule.name),
                   variables: rule.variables.map { VariableState($0) },
                   destination: rule.destination.map { ComponentState($0, variable: nil) })

--- a/macos/Fileaway/Core/VariableState.swift
+++ b/macos/Fileaway/Core/VariableState.swift
@@ -31,10 +31,10 @@ class VariableState: ObservableObject, Identifiable, Hashable {
         self.type = variable.type
     }
 
-    public init(_ variable: VariableState) {
-        id = variable.id
-        name = String(variable.name)
-        type = variable.type
+    public init(_ variableState: VariableState) {
+        id = UUID()
+        name = String(variableState.name)
+        type = variableState.type
     }
 
     public init(name: String, type: VariableType) {

--- a/macos/Fileaway/Views/ContentView.swift
+++ b/macos/Fileaway/Views/ContentView.swift
@@ -1,9 +1,22 @@
+// Copyright (c) 2018-2021 InSeven Limited
 //
-//  ContentView.swift
-//  Document Finder
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
 //
-//  Created by Jason Barrie Morley on 01/12/2020.
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
 //
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 import SwiftUI
 

--- a/macos/Fileaway/Views/DateView.swift
+++ b/macos/Fileaway/Views/DateView.swift
@@ -1,9 +1,22 @@
+// Copyright (c) 2018-2021 InSeven Limited
 //
-//  DateView.swift
-//  Document Finder
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
 //
-//  Created by Jason Barrie Morley on 04/12/2020.
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
 //
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 import SwiftUI
 

--- a/macos/Fileaway/Views/DirectoryView.swift
+++ b/macos/Fileaway/Views/DirectoryView.swift
@@ -1,9 +1,22 @@
+// Copyright (c) 2018-2021 InSeven Limited
 //
-//  DirectoryView.swift
-//  Document Finder
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
 //
-//  Created by Jason Barrie Morley on 02/12/2020.
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
 //
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 import AppKit
 import Combine
@@ -11,74 +24,6 @@ import Quartz
 import SwiftUI
 
 import Interact
-
-struct RightClickableSwiftUIView: NSViewRepresentable {
-
-    var onRightClickFocusChange: (Bool) -> Void
-
-    class Coordinator: NSObject, RightClickObservingViewDelegate {
-
-        var parent: RightClickableSwiftUIView
-
-        init(_ parent: RightClickableSwiftUIView) {
-            self.parent = parent
-        }
-
-        func rightClickFocusDidChange(focused: Bool) {
-            // TODO: Remove repeated entries here? Maybe this could be a publisher?
-            print("\(self) rightClickFocusDidChange: \(focused)")
-            parent.onRightClickFocusChange(focused)
-        }
-
-    }
-
-    func makeCoordinator() -> Coordinator {
-        Coordinator(self)
-    }
-
-    func makeNSView(context: Context) -> RightClickObservingView {
-        let view = RightClickObservingView()
-        view.delegate = context.coordinator
-        return view
-    }
-
-    func updateNSView(_ view: RightClickObservingView, context: NSViewRepresentableContext<RightClickableSwiftUIView>) {
-        view.delegate = context.coordinator
-    }
-
-}
-
-protocol RightClickObservingViewDelegate: NSObject {
-
-    func rightClickFocusDidChange(focused: Bool)
-
-}
-
-class RightClickObservingView : NSView {
-
-    weak var delegate: RightClickObservingViewDelegate?
-
-    override init(frame frameRect: NSRect) {
-        super.init(frame: frameRect)
-
-        let recognizer = ObservingGestureRecognizer { [weak self] in
-            self?.delegate?.rightClickFocusDidChange(focused: true)
-        }
-        addGestureRecognizer(recognizer)
-        NotificationCenter.default.addObserver(self, selector: #selector(didReceiveNotification),
-                                               name: NSNotification.Name(rawValue: "NSMenuDidCompleteInteractionNotification"),
-                                               object: nil)
-    }
-
-    @objc func didReceiveNotification(_ notification: NSNotification) {
-        delegate?.rightClickFocusDidChange(focused: false)
-    }
-
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-}
 
 struct DirectoryView: View {
 

--- a/macos/Fileaway/Views/FileRow.swift
+++ b/macos/Fileaway/Views/FileRow.swift
@@ -1,9 +1,22 @@
+// Copyright (c) 2018-2021 InSeven Limited
 //
-//  FileRow.swift
-//  Document Finder
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
 //
-//  Created by Jason Barrie Morley on 04/12/2020.
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
 //
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 import SwiftUI
 import QuickLook

--- a/macos/Fileaway/Views/KeyEventHandler.swift
+++ b/macos/Fileaway/Views/KeyEventHandler.swift
@@ -1,9 +1,22 @@
+// Copyright (c) 2018-2021 InSeven Limited
 //
-//  KeyEventHandler.swift
-//  Document Finder
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
 //
-//  Created by Jason Barrie Morley on 07/12/2020.
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
 //
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 import SwiftUI
 

--- a/macos/Fileaway/Views/Legacy.swift
+++ b/macos/Fileaway/Views/Legacy.swift
@@ -1,9 +1,22 @@
+// Copyright (c) 2018-2021 InSeven Limited
 //
-//  ArchiveWizard.swift
-//  Document Finder
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
 //
-//  Created by Jason Barrie Morley on 09/12/2020.
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
 //
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 import Combine
 import SwiftUI

--- a/macos/Fileaway/Views/MailboxRow.swift
+++ b/macos/Fileaway/Views/MailboxRow.swift
@@ -1,9 +1,22 @@
+// Copyright (c) 2018-2021 InSeven Limited
 //
-//  MailboxRow.swift
-//  Document Finder
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
 //
-//  Created by Jason Barrie Morley on 05/12/2020.
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
 //
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 import SwiftUI
 

--- a/macos/Fileaway/Views/PageLink.swift
+++ b/macos/Fileaway/Views/PageLink.swift
@@ -1,9 +1,22 @@
+// Copyright (c) 2018-2021 InSeven Limited
 //
-//  PageLink.swift
-//  Document Finder
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
 //
-//  Created by Jason Barrie Morley on 09/12/2020.
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
 //
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 import SwiftUI
 

--- a/macos/Fileaway/Views/PageView.swift
+++ b/macos/Fileaway/Views/PageView.swift
@@ -1,9 +1,22 @@
+// Copyright (c) 2018-2021 InSeven Limited
 //
-//  PageView.swift
-//  Document Finder
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
 //
-//  Created by Jason Barrie Morley on 09/12/2020.
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
 //
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 import SwiftUI
 

--- a/macos/Fileaway/Views/QuickLookPreview.swift
+++ b/macos/Fileaway/Views/QuickLookPreview.swift
@@ -1,9 +1,22 @@
+// Copyright (c) 2018-2021 InSeven Limited
 //
-//  QuickLookPreview.swift
-//  Document Finder
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
 //
-//  Created by Jason Barrie Morley on 09/12/2020.
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
 //
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 import Quartz
 import SwiftUI

--- a/macos/Fileaway/Views/ResponderView.swift
+++ b/macos/Fileaway/Views/ResponderView.swift
@@ -1,9 +1,22 @@
+// Copyright (c) 2018-2021 InSeven Limited
 //
-//  ResponderView.swift
-//  Document Finder
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
 //
-//  Created by Jason Barrie Morley on 05/12/2020.
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
 //
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 import SwiftUI
 

--- a/macos/Fileaway/Views/RightClickObservingView.swift
+++ b/macos/Fileaway/Views/RightClickObservingView.swift
@@ -18,51 +18,30 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import Foundation
 import SwiftUI
 
-import FileawayCore
+class RightClickObservingView : NSView {
 
-extension Component {
+    weak var delegate: RightClickObservingViewDelegate?
 
-    init(_ state: ComponentState) {
-        self.init(type: state.type, value: state.value)
-    }
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
 
-}
-
-class ComponentState: ObservableObject, Identifiable {
-
-    var id = UUID() // TODO: Why doesn't this work if it's a let.
-    @Published var value: String
-    @Published var type: ComponentType
-    var variable: VariableState? = nil
-
-    init(value: String, type: ComponentType, variable: VariableState?) {
-        self.value = value
-        self.type = type
-        self.variable = variable
-    }
-
-    init(_ component: Component, variable: VariableState?) {
-        value = component.value
-        type = component.type
-        self.variable = variable
-    }
-
-    // TODO: How do we actually copy???
-    init(_ component: ComponentState, variable: VariableState?) {
-        id = component.id
-        value = String(component.value)
-        type = component.type
-        self.variable = variable
-    }
-
-    func update() {
-        guard let variable = self.variable else {
-            return
+        let recognizer = ObservingGestureRecognizer { [weak self] in
+            self?.delegate?.rightClickFocusDidChange(focused: true)
         }
-        self.value = variable.name
+        addGestureRecognizer(recognizer)
+        NotificationCenter.default.addObserver(self, selector: #selector(didReceiveNotification),
+                                               name: NSNotification.Name(rawValue: "NSMenuDidCompleteInteractionNotification"),
+                                               object: nil)
+    }
+
+    @objc func didReceiveNotification(_ notification: NSNotification) {
+        delegate?.rightClickFocusDidChange(focused: false)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
     }
 
 }

--- a/macos/Fileaway/Views/RightClickableSwiftUIView.swift
+++ b/macos/Fileaway/Views/RightClickableSwiftUIView.swift
@@ -18,51 +18,46 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import Foundation
 import SwiftUI
 
-import FileawayCore
+struct RightClickableSwiftUIView: NSViewRepresentable {
 
-extension Component {
+    var onRightClickFocusChange: (Bool) -> Void
 
-    init(_ state: ComponentState) {
-        self.init(type: state.type, value: state.value)
+    class Coordinator: NSObject, RightClickObservingViewDelegate {
+
+        var parent: RightClickableSwiftUIView
+
+        init(_ parent: RightClickableSwiftUIView) {
+            self.parent = parent
+        }
+
+        func rightClickFocusDidChange(focused: Bool) {
+            // TODO: Remove repeated entries here? Maybe this could be a publisher?
+            print("\(self) rightClickFocusDidChange: \(focused)")
+            parent.onRightClickFocusChange(focused)
+        }
+
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+
+    func makeNSView(context: Context) -> RightClickObservingView {
+        let view = RightClickObservingView()
+        view.delegate = context.coordinator
+        return view
+    }
+
+    func updateNSView(_ view: RightClickObservingView, context: NSViewRepresentableContext<RightClickableSwiftUIView>) {
+        view.delegate = context.coordinator
     }
 
 }
 
-class ComponentState: ObservableObject, Identifiable {
+protocol RightClickObservingViewDelegate: NSObject {
 
-    var id = UUID() // TODO: Why doesn't this work if it's a let.
-    @Published var value: String
-    @Published var type: ComponentType
-    var variable: VariableState? = nil
-
-    init(value: String, type: ComponentType, variable: VariableState?) {
-        self.value = value
-        self.type = type
-        self.variable = variable
-    }
-
-    init(_ component: Component, variable: VariableState?) {
-        value = component.value
-        type = component.type
-        self.variable = variable
-    }
-
-    // TODO: How do we actually copy???
-    init(_ component: ComponentState, variable: VariableState?) {
-        id = component.id
-        value = String(component.value)
-        type = component.type
-        self.variable = variable
-    }
-
-    func update() {
-        guard let variable = self.variable else {
-            return
-        }
-        self.value = variable.name
-    }
+    func rightClickFocusDidChange(focused: Bool)
 
 }

--- a/macos/Fileaway/Views/SearchField.swift
+++ b/macos/Fileaway/Views/SearchField.swift
@@ -1,9 +1,22 @@
+// Copyright (c) 2018-2021 InSeven Limited
 //
-//  SearchField.swift
-//  Document Finder
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
 //
-//  Created by Jason Barrie Morley on 06/12/2020.
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
 //
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 import SwiftUI
 

--- a/macos/Fileaway/Views/Settings/DestinationList.swift
+++ b/macos/Fileaway/Views/Settings/DestinationList.swift
@@ -1,9 +1,22 @@
+// Copyright (c) 2018-2021 InSeven Limited
 //
-//  DestinationList.swift
-//  Fileaway
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
 //
-//  Created by Jason Barrie Morley on 27/12/2020.
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
 //
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 import SwiftUI
 

--- a/macos/Fileaway/Views/Settings/GeneralSettingsView.swift
+++ b/macos/Fileaway/Views/Settings/GeneralSettingsView.swift
@@ -1,9 +1,22 @@
+// Copyright (c) 2018-2021 InSeven Limited
 //
-//  GeneralSettingsView.swift
-//  Document Finder
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
 //
-//  Created by Jason Barrie Morley on 05/12/2020.
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
 //
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 import SwiftUI
 

--- a/macos/Fileaway/Views/Settings/RuleDetailView.swift
+++ b/macos/Fileaway/Views/Settings/RuleDetailView.swift
@@ -1,9 +1,22 @@
+// Copyright (c) 2018-2021 InSeven Limited
 //
-//  RuleDetailView.swift
-//  Fileaway
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
 //
-//  Created by Jason Barrie Morley on 27/12/2020.
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
 //
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 import SwiftUI
 

--- a/macos/Fileaway/Views/Settings/RulesSettingsView.swift
+++ b/macos/Fileaway/Views/Settings/RulesSettingsView.swift
@@ -1,9 +1,22 @@
+// Copyright (c) 2018-2021 InSeven Limited
 //
-//  RulesSettingsView.swift
-//  Fileaway
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
 //
-//  Created by Jason Barrie Morley on 27/12/2020.
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
 //
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 import SwiftUI
 

--- a/macos/Fileaway/Views/Settings/RulesSettingsView.swift
+++ b/macos/Fileaway/Views/Settings/RulesSettingsView.swift
@@ -86,7 +86,7 @@ struct RulesSettingsView: View {
                     HStack {
                         ListButtons {
                             do {
-                                let rule = try rules.new()
+                                let rule = try rules.new(preferredName: "Rule")
                                 selection = rule
                                 sheet = .rule(rule: rule)
                             } catch {

--- a/macos/Fileaway/Views/Settings/RulesSettingsView.swift
+++ b/macos/Fileaway/Views/Settings/RulesSettingsView.swift
@@ -39,9 +39,14 @@ struct RulesSettingsView: View {
         case rule(rule: RuleState)
     }
 
+    enum AlertType {
+        case duplicationFailure(error: Error)
+    }
+
     @ObservedObject var rules: RuleSet
     @State var selection: RuleState?
     @State var sheet: SheetType?
+    @State var alert: AlertType?
 
     var body: some View {
         HStack {
@@ -54,6 +59,15 @@ struct RulesSettingsView: View {
                             .onTapGesture(count: 2) {
                                 print("Double tapped!")
                                 sheet = .rule(rule: rule)
+                            }
+                            .contextMenu {
+                                Button("Duplicate") {
+                                    do {
+                                        let _ = try rules.duplicate(rule, preferredName: "Copy of " + rule.name)
+                                    } catch {
+                                        alert = .duplicationFailure(error: error)
+                                    }
+                                }
                             }
                     }
                     HStack {
@@ -96,6 +110,12 @@ struct RulesSettingsView: View {
                     RuleSheet(rule: rule)
                 }
             }
+            .alert(item: $alert) { alert in
+                switch alert {
+                case .duplicationFailure(let error):
+                    return Alert(title: Text("Duplicate Rule Failed"), message: Text(error.localizedDescription))
+                }
+            }
         }
     }
 
@@ -107,6 +127,17 @@ extension RulesSettingsView.SheetType: Identifiable {
         switch self {
         case .rule:
             return "rule"
+        }
+    }
+
+}
+
+extension RulesSettingsView.AlertType: Identifiable {
+
+    public var id: String {
+        switch self {
+        case .duplicationFailure(let error):
+            return "duplicationFailure:\(error)"
         }
     }
 

--- a/macos/Fileaway/Views/Settings/SettingsView.swift
+++ b/macos/Fileaway/Views/Settings/SettingsView.swift
@@ -1,9 +1,22 @@
+// Copyright (c) 2018-2021 InSeven Limited
 //
-//  SettingsView.swift
-//  Document Finder
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
 //
-//  Created by Jason Barrie Morley on 05/12/2020.
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
 //
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 import Combine
 import SwiftUI

--- a/macos/Fileaway/Views/Settings/VariableList.swift
+++ b/macos/Fileaway/Views/Settings/VariableList.swift
@@ -1,9 +1,22 @@
+// Copyright (c) 2018-2021 InSeven Limited
 //
-//  VariableList.swift
-//  Fileaway
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
 //
-//  Created by Jason Barrie Morley on 27/12/2020.
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
 //
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 import SwiftUI
 

--- a/macos/Fileaway/Views/Sidebar.swift
+++ b/macos/Fileaway/Views/Sidebar.swift
@@ -1,9 +1,22 @@
+// Copyright (c) 2018-2021 InSeven Limited
 //
-//  Sidebar.swift
-//  Document Finder
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
 //
-//  Created by Jason Barrie Morley on 04/12/2020.
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
 //
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 import SwiftUI
 

--- a/macos/Fileaway/Views/Wizard/ArchiveWizard.swift
+++ b/macos/Fileaway/Views/Wizard/ArchiveWizard.swift
@@ -1,9 +1,22 @@
+// Copyright (c) 2018-2021 InSeven Limited
 //
-//  ArchiveWizard.swift
-//  Document Finder
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
 //
-//  Created by Jason Barrie Morley on 14/12/2020.
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
 //
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 import SwiftUI
 

--- a/macos/Fileaway/Views/Wizard/DetailsPage.swift
+++ b/macos/Fileaway/Views/Wizard/DetailsPage.swift
@@ -92,6 +92,7 @@ struct DetailsPage: View {
 }
 
 extension DetailsPage.AlertType: Identifiable {
+
     public var id: String {
         switch self {
         case .error(let error):
@@ -100,4 +101,5 @@ extension DetailsPage.AlertType: Identifiable {
             return "duplicate:\(duplicateUrl)"
         }
     }
+    
 }

--- a/macos/Fileaway/Views/Wizard/DetailsPage.swift
+++ b/macos/Fileaway/Views/Wizard/DetailsPage.swift
@@ -1,9 +1,22 @@
+// Copyright (c) 2018-2021 InSeven Limited
 //
-//  DetailsPage.swift
-//  Document Finder
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
 //
-//  Created by Jason Barrie Morley on 14/12/2020.
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
 //
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 import SwiftUI
 

--- a/macos/Fileaway/Views/Wizard/TaskPage.swift
+++ b/macos/Fileaway/Views/Wizard/TaskPage.swift
@@ -1,9 +1,22 @@
+// Copyright (c) 2018-2021 InSeven Limited
 //
-//  TaskPage.swift
-//  Document Finder
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
 //
-//  Created by Jason Barrie Morley on 14/12/2020.
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
 //
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 import SwiftUI
 


### PR DESCRIPTION
It's often useful to be able to create a new rule based on another; this change adds support for duplicating rules by right-clicking on a rule and selecting 'Duplicate'.

The change also includes some drive-by fixes:

- add copyright notices to some of the Mac app source
- clean up some of the API around copy vs. mutate
- guarnatee uniqueness when adding rules
- improve error handling when editing rules