### PR TITLE
Move SearchField into Interact

### DIFF
--- a/macos/Fileaway-macOS.xcodeproj/project.pbxproj
+++ b/macos/Fileaway-macOS.xcodeproj/project.pbxproj
@@ -33,7 +33,6 @@
 		D88DF5FB258463310068404E /* LazyFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88DF5FA258463310068404E /* LazyFilter.swift */; };
 		D8B6D021257D962F00C7E472 /* AcceptsFirstResponder.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8B6D020257D962F00C7E472 /* AcceptsFirstResponder.swift */; };
 		D8B6D026257DBA8B00C7E472 /* SelectionTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8B6D025257DBA8B00C7E472 /* SelectionTracker.swift */; };
-		D8B6D02B257DBAF700C7E472 /* SearchField.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8B6D02A257DBAF700C7E472 /* SearchField.swift */; };
 		D8B6D030257DBB7D00C7E472 /* SelectionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8B6D02F257DBB7D00C7E472 /* SelectionManager.swift */; };
 		D8B6D035257E71CD00C7E472 /* QuickLookCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8B6D034257E71CD00C7E472 /* QuickLookCoordinator.swift */; };
 		D8B6D047257F0B4300C7E472 /* KeyEventHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8B6D046257F0B4300C7E472 /* KeyEventHandler.swift */; };
@@ -126,7 +125,6 @@
 		D88DF5FA258463310068404E /* LazyFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LazyFilter.swift; sourceTree = "<group>"; };
 		D8B6D020257D962F00C7E472 /* AcceptsFirstResponder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcceptsFirstResponder.swift; sourceTree = "<group>"; };
 		D8B6D025257DBA8B00C7E472 /* SelectionTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectionTracker.swift; sourceTree = "<group>"; };
-		D8B6D02A257DBAF700C7E472 /* SearchField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchField.swift; sourceTree = "<group>"; };
 		D8B6D02F257DBB7D00C7E472 /* SelectionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectionManager.swift; sourceTree = "<group>"; };
 		D8B6D034257E71CD00C7E472 /* QuickLookCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickLookCoordinator.swift; sourceTree = "<group>"; };
 		D8B6D046257F0B4300C7E472 /* KeyEventHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyEventHandler.swift; sourceTree = "<group>"; };
@@ -238,7 +236,6 @@
 				D8D78A9E2580DE250088890F /* PageView.swift */,
 				D8D78A912580DD750088890F /* QuickLookPreview.swift */,
 				D8DC5045257C0795009B3ECC /* ResponderView.swift */,
-				D8B6D02A257DBAF700C7E472 /* SearchField.swift */,
 				D821E945257AA5FC005D3205 /* Sidebar.swift */,
 				D8D78AA62580DF190088890F /* Legacy.swift */,
 				D8FDDA2B261A43B30060D256 /* RightClickObservingView.swift */,
@@ -538,7 +535,6 @@
 				D8F8BE3725881C1A0010432F /* TaskPage.swift in Sources */,
 				D8E7F9FD2599B10500C7409B /* BackChannel.swift in Sources */,
 				D8E7F9C125999DB300C7409B /* Variable.swift in Sources */,
-				D8B6D02B257DBAF700C7E472 /* SearchField.swift in Sources */,
 				D8E7F9F02599B08600C7409B /* VariableState.swift in Sources */,
 				D8D78A9A2580DDF40088890F /* PageLink.swift in Sources */,
 				D87B126525851218004EC884 /* EventModifiers.swift in Sources */,

--- a/macos/Fileaway/Modifiers/Toolbar.swift
+++ b/macos/Fileaway/Modifiers/Toolbar.swift
@@ -20,6 +20,8 @@
 
 import SwiftUI
 
+import Interact
+
 struct Toolbar: ViewModifier {
 
     @Environment(\.openURL) var openURL


### PR DESCRIPTION
In order to use SearchField in other projects, it needs to be moved into the Interact Swift package.