### PR TITLE
Save the main window frame

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,19 @@ Right now the macOS and iOS apps are incredibly divergent having been written wi
 
 ## Changelog
 
-### Version 0.1.1 (macOS)
+### macOS
+
+#### Unreleased
+
+Changes on `main` pending release.
+
+- Save the window size
+
+#### Version 0.1.1
 
 - Support duplicating rules
 
-### Version 0.1.0 (macOS)
+#### Version 0.1.0
 
 Initial release with support for a single inbox and archive directories, rules wizard, and simple rule editing.
 

--- a/macos/Fileaway/FileawayApp.swift
+++ b/macos/Fileaway/FileawayApp.swift
@@ -97,6 +97,7 @@ struct FileawayApp: App {
         WindowGroup(id: "MainWindow") {
             ContentView(manager: appDelegate.manager)
                 .environment(\.manager, appDelegate.manager)
+                .frameAutosaveName("Main Window")
         }
         .commands {
             GlobalCommands()


### PR DESCRIPTION
This requires an update to the Interact package to pick up the new window frame autosaving functionality.