### PR TITLE
fix: Make double-clicking to open rules in settings more reliable

### DIFF
--- a/macos/Fileaway/Views/Settings/RulesSettingsView.swift
+++ b/macos/Fileaway/Views/Settings/RulesSettingsView.swift
@@ -43,10 +43,12 @@ struct RulesSettingsView: View {
                 ScrollViewReader { scrollView in
                     List(rules.mutableRules, id: \.self, selection: $selection) { rule in
                         Text(rule.name)
+                            .frame(maxWidth: .infinity, alignment: .topLeading)
                             .lineLimit(1)
-                            .id(rule.id)
-                            .onTapGesture(count: 2) {
-                                print("Double tapped!")
+                            .contentShape(Rectangle())
+                            .onClick {
+                                selection = rule
+                            } doubleClick: {
                                 sheet = .rule(rule: rule)
                             }
                             .contextMenu {


### PR DESCRIPTION
The tap handler which was trying to add double-click support to open rules in settings made it impossible to select rules if you clicked on the text, and impossible to double-click to open if you clicked anywhere other than the text. 🥴