### PR TITLE
ci: Introduce a dedicated script to add a version tag and GitHub release

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -41,4 +41,5 @@ jobs:
     - name: Archive the binary
       uses: actions/upload-artifact@v2
       with:
-        path: build/*.zip
+        name: Artifacts
+        path: build/Artifacts.zip

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-changes --scope macOS release --push --command 'gh release create $CHANGES_TAG --prerelease --title "$CHANGES_TITLE" --notes "$CHANGES_NOTES"'
+changes --scope macOS release --push --command 'gh release create $CHANGES_TAG --prerelease --title "$CHANGES_TITLE" --notes "$CHANGES_NOTES"' "$@"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+changes --scope macOS release --push --command 'gh release create $CHANGES_TAG --prerelease --title "$CHANGES_TITLE" --notes "$CHANGES_NOTES"'


### PR DESCRIPTION
This change makes use of the new functionality in 'changes' to run the GitHub cli and create a release based on the newly created version tag.

It includes a drive-by fix to add a flag to the build script to skip notarisation for local builds (`--skip-notarize`), and changes the packaging structure slightly to match better the release needs.