### PR TITLE
fix: Fixed a crash when closing the Rules Wizard

### DIFF
--- a/macos/Fileaway/Views/QuickLookPreview.swift
+++ b/macos/Fileaway/Views/QuickLookPreview.swift
@@ -28,6 +28,9 @@ struct QuickLookPreview: NSViewRepresentable {
     func makeNSView(context: NSViewRepresentableContext<QuickLookPreview>) -> QLPreviewView {
         let preview = QLPreviewView(frame: .zero, style: .compact)
         preview?.autostarts = true
+        // TODO: Ensure the QLPreviewView instances are not leaking #100
+        //       https://github.com/jbmorley/fileaway/issues/100
+        preview?.shouldCloseWithWindow = false // TODO: We should cleanup somehow.
         preview?.previewItem = url as QLPreviewItem
         return preview ?? QLPreviewView()
     }

--- a/macos/Fileaway/Views/QuickLookPreview.swift
+++ b/macos/Fileaway/Views/QuickLookPreview.swift
@@ -30,7 +30,7 @@ struct QuickLookPreview: NSViewRepresentable {
         preview?.autostarts = true
         // TODO: Ensure the QLPreviewView instances are not leaking #100
         //       https://github.com/jbmorley/fileaway/issues/100
-        preview?.shouldCloseWithWindow = false // TODO: We should cleanup somehow.
+        preview?.shouldCloseWithWindow = false
         preview?.previewItem = url as QLPreviewItem
         return preview ?? QLPreviewView()
     }


### PR DESCRIPTION
It looks a lot like the SwiftUI-QLPreviewView interaction has changed in a recent release that means the QLPreviewView close is now occuring at the wrong time, leading to a crash. This workaround may introduce a memory leak (see https://github.com/jbmorley/fileaway/issues/100).