### PR TITLE
ci(macOS): Upload the release files separately to work around a GitHub bug

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -121,8 +121,7 @@ security unlock-keychain -p "$TEMPORARY_KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
 security list-keychain -d user -s "$KEYCHAIN_PATH"
 
 # Archive and export the build.
-KEYCHAIN_FLAGS="--keychain=\"${KEYCHAIN_PATH}\""
-xcodebuild -workspace Fileaway.xcworkspace -scheme "Fileaway macOS" -config Release -archivePath "$ARCHIVE_PATH"  OTHER_CODE_SIGN_FLAGS="$KEYCHAIN_FLAGS" BUILD_NUMBER=$BUILD_NUMBER MARKETING_VERSION=$VERSION_NUMBER archive
+xcodebuild -workspace Fileaway.xcworkspace -scheme "Fileaway macOS" -config Release -archivePath "$ARCHIVE_PATH"  OTHER_CODE_SIGN_FLAGS="--keychain=\"${KEYCHAIN_PATH}\"" BUILD_NUMBER=$BUILD_NUMBER MARKETING_VERSION=$VERSION_NUMBER archive | xcpretty
 xcodebuild -archivePath "$ARCHIVE_PATH" -exportArchive -exportPath "$BUILD_DIRECTORY" -exportOptionsPlist "ExportOptions.plist"
 
 APP_BASENAME="Fileaway.app"
@@ -151,5 +150,5 @@ rm -rf "$TEMPORARY_DIRECTORY"
 if $RELEASE || $TRY_RELEASE ; then
     # List the current tags just to check GitHub has them.
     git tag
-    "$CHANGES_SCRIPT" --scope macOS release --skip-if-empty --push --command 'gh release create "$CHANGES_TAG" --prerelease --title "$CHANGES_TITLE" --notes "$CHANGES_NOTES" build/Fileaway-macOS*.zip'
+    "$CHANGES_SCRIPT" --scope macOS release --skip-if-empty --push --command 'scripts/release.sh'
 fi

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Copyright (c) 2018-2021 InSeven Limited
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+set -e
+set -o pipefail
+set -x
+set -u
+
+# List the current tags which (by now) should include one for the release we're about to create.
+echo "All tags:"
+git tag
+
+# Log the state for debugging.
+echo "CHANGES_TAG: $CHANGES_TAG"
+echo "CHANGES_TITLE: $CHANGES_TITLE"
+echo "CHANGES_NOTES: $CHANGES_NOTES"
+echo "CHANGES_NOTES_FILE: $CHANGES_NOTES_FILE"
+cat "$CHANGES_NOTES_FILE"
+
+# Actually make the release.
+# Disappointingly, there seems to be an issue where the release create step doesn't use the specified tag if a set of
+# files are also provided for upload. To work around this, we instead perform a secondary upload step.
+gh release create "$CHANGES_TAG" --prerelease --title "$CHANGES_TITLE" --notes-file "$CHANGES_NOTES_FILE"
+gh release upload "$CHANGES_TAG" build/Fileaway-macOS*.zip


### PR DESCRIPTION
This change also moves the actual release operation out to a separate script to make it easier to improve logging when running the GitHub cli.
