### PR TITLE
ci(macOS): Move changes dependency into the scripts folder

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "interact"]
 	path = interact
 	url = git@github.com:jbmorley/interact.git
-[submodule "changes"]
-	path = changes
+[submodule "scripts/changes"]
+	path = scripts/changes
 	url = git@github.com:jbmorley/changes.git

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -35,7 +35,7 @@ KEYCHAIN_PATH="${TEMPORARY_DIRECTORY}/temporary.keychain"
 ARCHIVE_PATH="${BUILD_DIRECTORY}/Fileaway.xcarchive"
 FASTLANE_ENV_PATH="${ROOT_DIRECTORY}/fastlane/.env"
 
-CHANGES_SCRIPT="${ROOT_DIRECTORY}/changes/changes"
+CHANGES_SCRIPT="${ROOT_DIRECTORY}/scripts/changes/changes"
 
 # Process the command line arguments.
 POSITIONAL=()


### PR DESCRIPTION
There’s no need for this to clutter the top-level directory.