### PR TITLE
ci(macOS): Preserve symlinks in the app zip and verify the output

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "scripts/changes"]
 	path = scripts/changes
 	url = git@github.com:jbmorley/changes.git
+[submodule "scripts/build-tools"]
+	path = scripts/build-tools
+	url = git@github.com:jbmorley/build-tools.git

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -25,9 +25,9 @@ set -o pipefail
 set -x
 set -u
 
-SCRIPT_DIRECTORY="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+SCRIPTS_DIRECTORY="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
-ROOT_DIRECTORY="${SCRIPT_DIRECTORY}/.."
+ROOT_DIRECTORY="${SCRIPTS_DIRECTORY}/.."
 BUILD_DIRECTORY="${ROOT_DIRECTORY}/build"
 TEMPORARY_DIRECTORY="${ROOT_DIRECTORY}/temp"
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -35,7 +35,8 @@ KEYCHAIN_PATH="${TEMPORARY_DIRECTORY}/temporary.keychain"
 ARCHIVE_PATH="${BUILD_DIRECTORY}/Fileaway.xcarchive"
 FASTLANE_ENV_PATH="${ROOT_DIRECTORY}/fastlane/.env"
 
-CHANGES_SCRIPT="${ROOT_DIRECTORY}/scripts/changes/changes"
+CHANGES_SCRIPT="${SCRIPTS_DIRECTORY}/changes/changes"
+BUILD_TOOLS_SCRIPT="${SCRIPTS_DIRECTORY}/build-tools/build-tools"
 
 # Process the command line arguments.
 POSITIONAL=()
@@ -137,7 +138,9 @@ fi
 
 # Archive the results.
 pushd "$BUILD_DIRECTORY"
-zip -r "Fileaway-macOS-${VERSION_NUMBER}.zip" "$APP_BASENAME"
+ZIP_BASENAME="Fileaway-macOS-${VERSION_NUMBER}.zip"
+zip -r --symlinks "$ZIP_BASENAME" "$APP_BASENAME"
+"$BUILD_TOOLS_SCRIPT" verify-notarized-zip "$ZIP_BASENAME"
 rm -r "$APP_BASENAME"
 zip -r "Artifacts.zip" "."
 popd


### PR DESCRIPTION
Notarized apps can become invalid if they’re compressed in a way that follows symlinks. This change ensures that the zip preserves the symlinks and adds a belt-and-braces check to ensure the resulting zip is still notarized.

See https://github.com/jbmorley/fileaway/issues/120.