### PR TITLE
fix(macOS): Duplicate and delete context menu items act on all selected rules in the Rules editor

### DIFF
--- a/macos/Fileaway-macOS.xcodeproj/project.pbxproj
+++ b/macos/Fileaway-macOS.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		D88DAA7D26420C5100BC7AD6 /* NSImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88DAA7C26420C5100BC7AD6 /* NSImage.swift */; };
 		D88DAA7F26420F8E00BC7AD6 /* IconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88DAA7E26420F8E00BC7AD6 /* IconView.swift */; };
 		D88DF5FB258463310068404E /* LazyFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88DF5FA258463310068404E /* LazyFilter.swift */; };
+		D8B33E872645E445005DA5C2 /* MenuItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8B33E862645E445005DA5C2 /* MenuItem.swift */; };
 		D8B657E826421D5B009DE837 /* LocationMenuItems.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8B657E726421D5B009DE837 /* LocationMenuItems.swift */; };
 		D8B657EA26421ECF009DE837 /* Alert.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8B657E926421ECF009DE837 /* Alert.swift */; };
 		D8B657EC2642D2C5009DE837 /* RulesSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8B657EB2642D2C5009DE837 /* RulesSettingsView.swift */; };
@@ -141,6 +142,7 @@
 		D88DAA7C26420C5100BC7AD6 /* NSImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSImage.swift; sourceTree = "<group>"; };
 		D88DAA7E26420F8E00BC7AD6 /* IconView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconView.swift; sourceTree = "<group>"; };
 		D88DF5FA258463310068404E /* LazyFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LazyFilter.swift; sourceTree = "<group>"; };
+		D8B33E862645E445005DA5C2 /* MenuItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuItem.swift; sourceTree = "<group>"; };
 		D8B657E726421D5B009DE837 /* LocationMenuItems.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationMenuItems.swift; sourceTree = "<group>"; };
 		D8B657E926421ECF009DE837 /* Alert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Alert.swift; sourceTree = "<group>"; };
 		D8B657EB2642D2C5009DE837 /* RulesSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RulesSettingsView.swift; sourceTree = "<group>"; };
@@ -268,6 +270,7 @@
 				D8FDDA30261A442B0060D256 /* RightClickableSwiftUIView.swift */,
 				D8FDDA2B261A43B30060D256 /* RightClickObservingView.swift */,
 				D821E945257AA5FC005D3205 /* Sidebar.swift */,
+				D8B33E862645E445005DA5C2 /* MenuItem.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -632,6 +635,7 @@
 				D8D78AA72580DF190088890F /* Legacy.swift in Sources */,
 				D8B6D030257DBB7D00C7E472 /* SelectionManager.swift in Sources */,
 				D85C9572257999130007AE1E /* FileManager.swift in Sources */,
+				D8B33E872645E445005DA5C2 /* MenuItem.swift in Sources */,
 				D8F8BE1D2588192F0010432F /* DetailsPage.swift in Sources */,
 				D8B657EE2642D40F009DE837 /* LocationsEditor.swift in Sources */,
 			);

--- a/macos/Fileaway/Views/MenuItem.swift
+++ b/macos/Fileaway/Views/MenuItem.swift
@@ -1,0 +1,79 @@
+// Copyright (c) 2018-2021 InSeven Limited
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import SwiftUI
+
+struct MenuItemItemLimitKey: EnvironmentKey {
+    static var defaultValue: Int = 0
+}
+
+extension EnvironmentValues {
+
+    var itemLimit: Int {
+        get { self[MenuItemItemLimitKey.self] }
+        set { self[MenuItemItemLimitKey.self] = newValue }
+    }
+
+}
+
+struct MenuItem<Item>: View where Item: Hashable {
+
+    @Environment(\.itemLimit) private var itemLimit
+
+    var label: String
+    var selection: Binding<Set<Item>>
+    var item: Item
+    var perform: (Set<Item>) -> Void
+
+    init(_ label: String, selection: Binding<Set<Item>>, item: Item, perform: @escaping (Set<Item>) -> Void) {
+        self.label = label
+        self.selection = selection
+        self.item = item
+        self.perform = perform
+    }
+
+    var items: Set<Item> {
+        if selection.wrappedValue.contains(item) {
+            return selection.wrappedValue
+        } else {
+            return [item]
+        }
+    }
+
+    var disabled: Bool {
+        return itemLimit > 0 && items.count > itemLimit
+    }
+
+    var body: some View {
+        Button(label) {
+            self.perform(items)
+        }
+        .disabled(disabled)
+    }
+
+}
+
+extension View {
+
+    func itemLimit(_ itemLimit: Int) -> some View {
+        self.environment(\.itemLimit, itemLimit)
+    }
+
+}

--- a/macos/Fileaway/Views/Settings/RulesEditor.swift
+++ b/macos/Fileaway/Views/Settings/RulesEditor.swift
@@ -75,7 +75,7 @@ struct RulesEditor: View {
     func delete(rules: Set<RuleState>) {
         do {
             try rules.remove(from: ruleSet)
-            selection = []  // TODO: Better implementation.
+            selection = selection.filter { !rules.contains($0) }
         } catch {
             alert = .error(error: error)
         }

--- a/macos/Fileaway/Views/Settings/RulesSettingsView.swift
+++ b/macos/Fileaway/Views/Settings/RulesSettingsView.swift
@@ -36,7 +36,7 @@ struct RulesSettingsView: View {
             }
             GroupBox {
                 if let ruleSet = manager.directories.first { $0.id == selection }?.ruleSet {
-                    RulesEditor(rules: ruleSet)
+                    RulesEditor(ruleSet: ruleSet)
                         .padding(4)
                 } else {
                     Text("No Archive Selected")


### PR DESCRIPTION
This change introduces a new SwiftUI View, `MenuItem` that correctly determines the items that the current context menu should act upon. This is necessary as the loop item in the `ForEach` isn't actually the focused item--macOS uses the loop item _if_ there is no existing selection or the loop item is outside the current selection, or the selected items if the loop item / right click item is within the selection.