### PR TITLE
fix(macOS): Set the initial directory when picking rules destinations

### DIFF
--- a/macos/Fileaway/Views/Settings/DestinationList.swift
+++ b/macos/Fileaway/Views/Settings/DestinationList.swift
@@ -35,6 +35,15 @@ struct ComponentView: View {
                         let openPanel = NSOpenPanel()
                         openPanel.canChooseFiles = false
                         openPanel.canChooseDirectories = true
+                        openPanel.canCreateDirectories = true
+                        var isDirectory = ObjCBool(true)
+                        let currentDirectory = rule.rootUrl.appendingPathComponent(component.value)
+                        if FileManager.default.fileExists(atPath: currentDirectory.path,
+                                                          isDirectory: &isDirectory) && isDirectory.boolValue {
+                            openPanel.directoryURL = currentDirectory
+                        } else {
+                            openPanel.directoryURL = rule.rootUrl
+                        }
                         guard openPanel.runModal() == NSApplication.ModalResponse.OK,
                               let url = openPanel.url,
                               let relativePath = url.relativePath(from: rule.rootUrl) else {


### PR DESCRIPTION
The directory picker in the Rules editor didn’t have a default location, meaning it opened in the last directory the user had used. This is confusing and makes it really easy to mistakenly pick a directory that’s not contained within the archive root. This change uses the existing directory if it exists, and the root of the archive otherwise.