### PR TITLE
fix: Only strip dates at the beginning of filenames

### DIFF
--- a/core/FileawayCore.xcodeproj/project.pbxproj
+++ b/core/FileawayCore.xcodeproj/project.pbxproj
@@ -349,6 +349,7 @@
 				TargetAttributes = {
 					D8D14D9F216E3E0E00D6E1DF = {
 						CreatedOnToolsVersion = 10.0;
+						LastSwiftMigration = 1250;
 					};
 					D8D14DA7216E3E0E00D6E1DF = {
 						CreatedOnToolsVersion = 10.0;

--- a/core/FileawayCore.xcodeproj/project.pbxproj
+++ b/core/FileawayCore.xcodeproj/project.pbxproj
@@ -19,6 +19,8 @@
 		D84E50C62654B0DE00496524 /* Task.swift in Sources */ = {isa = PBXBuildFile; fileRef = D84E50C42654B0DE00496524 /* Task.swift */; };
 		D876A3BD26548C61006D19FB /* BackChannel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D876A3BC26548C61006D19FB /* BackChannel.swift */; };
 		D876A3BE26548C61006D19FB /* BackChannel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D876A3BC26548C61006D19FB /* BackChannel.swift */; };
+		D88B86FD2656D8BF004F2F60 /* DateInstance.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88B86FC2656D8BF004F2F60 /* DateInstance.swift */; };
+		D88B86FE2656D8BF004F2F60 /* DateInstance.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88B86FC2656D8BF004F2F60 /* DateInstance.swift */; };
 		D898E653265578EC005EA6DE /* FileInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = D898E652265578EC005EA6DE /* FileInfo.swift */; };
 		D898E654265578EC005EA6DE /* FileInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = D898E652265578EC005EA6DE /* FileInfo.swift */; };
 		D898E6592655796B005EA6DE /* String.swift in Sources */ = {isa = PBXBuildFile; fileRef = D898E6582655796B005EA6DE /* String.swift */; };
@@ -41,6 +43,8 @@
 		D8D14DB8216E3E1400D6E1DF /* VariableProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8D14D57216E3BAE00D6E1DF /* VariableProvider.swift */; };
 		D8D14DB9216E3E1400D6E1DF /* Manager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8D14D58216E3BAE00D6E1DF /* Manager.swift */; };
 		D8D14DD0216F015F00D6E1DF /* FileawayCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D8D14DC7216F015F00D6E1DF /* FileawayCore.framework */; };
+		D8D1732E265698610069326C /* TitleFinderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8D1732C2656985E0069326C /* TitleFinderTests.swift */; };
+		D8D1732F265698620069326C /* TitleFinderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8D1732C2656985E0069326C /* TitleFinderTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -70,6 +74,7 @@
 		D84E50C12654B0B000496524 /* VariableType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VariableType.swift; sourceTree = "<group>"; };
 		D84E50C42654B0DE00496524 /* Task.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Task.swift; sourceTree = "<group>"; };
 		D876A3BC26548C61006D19FB /* BackChannel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackChannel.swift; sourceTree = "<group>"; };
+		D88B86FC2656D8BF004F2F60 /* DateInstance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateInstance.swift; sourceTree = "<group>"; };
 		D898E652265578EC005EA6DE /* FileInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileInfo.swift; sourceTree = "<group>"; };
 		D898E6582655796B005EA6DE /* String.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = String.swift; sourceTree = "<group>"; };
 		D898E65B26557AC3005EA6DE /* DateFinder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateFinder.swift; sourceTree = "<group>"; };
@@ -87,6 +92,7 @@
 		D8D14DCA216F015F00D6E1DF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D8D14DCF216F015F00D6E1DF /* FileawayCore iOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "FileawayCore iOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D8D14DD6216F015F00D6E1DF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		D8D1732C2656985E0069326C /* TitleFinderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleFinderTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -150,17 +156,18 @@
 		D81F7C47216E3AA80070AAA0 /* FileawayCore */ = {
 			isa = PBXGroup;
 			children = (
-				D898E66126557B91005EA6DE /* Extensions */,
 				D84E50C72654B56700496524 /* Configuration */,
+				D898E66126557B91005EA6DE /* Extensions */,
 				D876A3BC26548C61006D19FB /* BackChannel.swift */,
+				D898E65B26557AC3005EA6DE /* DateFinder.swift */,
+				D88B86FC2656D8BF004F2F60 /* DateInstance.swift */,
 				D81F7C48216E3AA80070AAA0 /* FileawayCore.h */,
 				D898E652265578EC005EA6DE /* FileInfo.swift */,
 				D81F7C49216E3AA80070AAA0 /* Info.plist */,
 				D8D14D58216E3BAE00D6E1DF /* Manager.swift */,
 				D84E50C42654B0DE00496524 /* Task.swift */,
-				D8D14D57216E3BAE00D6E1DF /* VariableProvider.swift */,
-				D898E65B26557AC3005EA6DE /* DateFinder.swift */,
 				D898E65E26557AFD005EA6DE /* TitleFinder.swift */,
+				D8D14D57216E3BAE00D6E1DF /* VariableProvider.swift */,
 			);
 			path = FileawayCore;
 			sourceTree = "<group>";
@@ -170,6 +177,7 @@
 			children = (
 				D898E66F2655849C005EA6DE /* Extensions */,
 				D898E66226557C28005EA6DE /* DateFinderTests.swift */,
+				D8D1732C2656985E0069326C /* TitleFinderTests.swift */,
 				D81F7C55216E3AA90070AAA0 /* Info.plist */,
 			);
 			path = FileawayCoreTests;
@@ -422,6 +430,7 @@
 				D876A3BE26548C61006D19FB /* BackChannel.swift in Sources */,
 				D84E50C52654B0DE00496524 /* Task.swift in Sources */,
 				D8D14DB7216E3E1400D6E1DF /* Configuration.swift in Sources */,
+				D88B86FD2656D8BF004F2F60 /* DateInstance.swift in Sources */,
 				D898E654265578EC005EA6DE /* FileInfo.swift in Sources */,
 				D898E66D2655848D005EA6DE /* Calendar.swift in Sources */,
 			);
@@ -431,6 +440,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D8D1732E265698610069326C /* TitleFinderTests.swift in Sources */,
 				D898E66526557C69005EA6DE /* DateFinderTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -451,6 +461,7 @@
 				D876A3BD26548C61006D19FB /* BackChannel.swift in Sources */,
 				D84E50C62654B0DE00496524 /* Task.swift in Sources */,
 				D8BCA524216F08DF002A624D /* Configuration.swift in Sources */,
+				D88B86FE2656D8BF004F2F60 /* DateInstance.swift in Sources */,
 				D898E653265578EC005EA6DE /* FileInfo.swift in Sources */,
 				D898E66E2655848D005EA6DE /* Calendar.swift in Sources */,
 			);
@@ -460,6 +471,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D8D1732F265698620069326C /* TitleFinderTests.swift in Sources */,
 				D898E66626557C6A005EA6DE /* DateFinderTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/core/FileawayCore/DateFinder.swift
+++ b/core/FileawayCore/DateFinder.swift
@@ -20,7 +20,6 @@
 
 import Foundation
 
-// TODO: Remove this cache? / String extension?
 class DateFinder {
 
     static var dateFormatter: DateFormatter = {

--- a/core/FileawayCore/DateFinder.swift
+++ b/core/FileawayCore/DateFinder.swift
@@ -22,6 +22,12 @@ import Foundation
 
 class DateFinder {
 
+    // TODO: Revisit the caching in DateFinder and TitleFinder #160
+    //       https://github.com/jbmorley/fileaway/issues/160
+    static var cache: NSCache<NSString, NSArray> = {
+        return NSCache()
+    }()
+
     static var dateFormatter: DateFormatter = {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy-MM-dd"
@@ -29,6 +35,13 @@ class DateFinder {
     }()
 
     static func dateInstances(from string: String) -> Array<DateInstance> {
+
+        // Check the cache.
+        if let dates = Self.cache.object(forKey: string as NSString) as? Array<DateInstance> {
+            return dates
+        }
+
+        // Find the dates.
         let types: NSTextCheckingResult.CheckingType = [.date]
         let detector = try! NSDataDetector(types: types.rawValue)
         let matches = detector.matches(in: string, options: [], range: NSRange(location: 0, length: string.count))
@@ -38,6 +51,10 @@ class DateFinder {
             }
             return DateInstance(date: date, range: textCheckingResult.range)
         }
+
+        // Update the cache.
+        Self.cache.setObject(dateInstances as NSArray, forKey: string as NSString)
+
         return dateInstances
     }
 

--- a/core/FileawayCore/DateInstance.swift
+++ b/core/FileawayCore/DateInstance.swift
@@ -20,26 +20,9 @@
 
 import Foundation
 
-// TODO: Remove this cache? / String extension?
-class DateFinder {
+struct DateInstance {
 
-    static var dateFormatter: DateFormatter = {
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy-MM-dd"
-        return dateFormatter
-    }()
-
-    static func dateInstances(from string: String) -> Array<DateInstance> {
-        let types: NSTextCheckingResult.CheckingType = [.date]
-        let detector = try! NSDataDetector(types: types.rawValue)
-        let matches = detector.matches(in: string, options: [], range: NSRange(location: 0, length: string.count))
-        let dateInstances: Array<DateInstance> = matches.compactMap { textCheckingResult in
-            guard let date = textCheckingResult.date else {
-                return nil
-            }
-            return DateInstance(date: date, range: textCheckingResult.range)
-        }
-        return dateInstances
-    }
+    let date: Date
+    let range: NSRange
 
 }

--- a/core/FileawayCore/FileInfo.swift
+++ b/core/FileawayCore/FileInfo.swift
@@ -36,7 +36,7 @@ public class FileInfo: Identifiable, Hashable {
     public init(url: URL) {
         self.url = url
         let name = url.lastPathComponent.deletingPathExtension
-        self.date = DateFinder.dates(from: name).first
+        self.date = DateFinder.dateInstances(from: name).map { $0.date }.first
         let title = TitleFinder.title(from: name)
         self.name = title.isEmpty ? name : title
         self.directoryUrl = url.deletingLastPathComponent()

--- a/core/FileawayCoreTests/DateFinderTests.swift
+++ b/core/FileawayCoreTests/DateFinderTests.swift
@@ -51,12 +51,12 @@ class DateFinderTests: XCTestCase {
     }
 
     func testDateFromString() {
-        let dates = dates(from: "2018-12-23 Document title")
+        let dates = self.dates(from: "2018-12-23 Document title")
         XCTAssertTrue(dates.matches([date(2018, 12, 23)], granularity: .day))
     }
 
     func testMultipleDatesFromString() {
-        let dates = dates(from: "2018-12-23 Document title 2021-05-19")
+        let dates = self.dates(from: "2018-12-23 Document title 2021-05-19")
         XCTAssertTrue(dates.matches([date(2018, 12, 23), date(2021, 05, 19)], granularity: .day))
     }
 

--- a/core/FileawayCoreTests/DateFinderTests.swift
+++ b/core/FileawayCoreTests/DateFinderTests.swift
@@ -22,6 +22,22 @@ import XCTest
 
 @testable import FileawayCore
 
+extension Array where Element == Date {
+
+    func matches(_ array: Array<Element>, granularity: Calendar.Component) -> Bool {
+        guard self.count == array.count else {
+            return false
+        }
+        for (index, date) in enumerated() {
+            if Calendar.gregorian.compare(date, to: array[index], toGranularity: granularity) != .orderedSame {
+                return false
+            }
+        }
+        return true
+    }
+
+}
+
 class DateFinderTests: XCTestCase {
 
     var calendar: Calendar = Calendar.gregorian
@@ -30,14 +46,18 @@ class DateFinderTests: XCTestCase {
         Calendar.gregorian.date(year, month, day)!
     }
 
+    func dates(from string: String) -> Array<Date> {
+        return DateFinder.dateInstances(from: string).map { $0.date }
+    }
+
     func testDateFromString() {
-        let dates = DateFinder.dates(from: "2018-12-23 Document title")
-        XCTAssertEqual(dates, [date(2018, 12, 23)])
+        let dates = dates(from: "2018-12-23 Document title")
+        XCTAssertTrue(dates.matches([date(2018, 12, 23)], granularity: .day))
     }
 
     func testMultipleDatesFromString() {
-        let dates = DateFinder.dates(from: "2018-12-23 Document title 2021-05-19")
-        XCTAssertEqual(dates, [date(2018, 12, 23), date(2021, 05, 19)])
+        let dates = dates(from: "2018-12-23 Document title 2021-05-19")
+        XCTAssertTrue(dates.matches([date(2018, 12, 23), date(2021, 05, 19)], granularity: .day))
     }
 
 }

--- a/core/FileawayCoreTests/TitleFinderTests.swift
+++ b/core/FileawayCoreTests/TitleFinderTests.swift
@@ -31,28 +31,28 @@ class TitleFinderTests: XCTestCase {
     }
 
     func testSingleDate() {
-        let title = TitleFinder.title(from: "2018-12-23 Document title")
-        XCTAssertEqual(title, "Document title")
+        XCTAssertEqual(TitleFinder.title(from: "2018-12-23 Document title"),
+                       "Document title")
     }
 
     func testSingleDateLeadingWhitespace() {
-        let title = TitleFinder.title(from: " 2018-12-23 Document title")
-        XCTAssertEqual(title, "Document title")
+        XCTAssertEqual(TitleFinder.title(from: " 2018-12-23 Document title"),
+                       "Document title")
     }
 
     func testComplexDate() {
-        let title = TitleFinder.title(from: "Dec 23, 2018 Document title")
-        XCTAssertEqual(title, "Document title")
+        XCTAssertEqual(TitleFinder.title(from: "Dec 23, 2018 Document title"),
+                       "Document title")
     }
 
     func testMultipleDates() {
-        let title = TitleFinder.title(from: "2018-12-23 Document title 2021-05-19")
-        XCTAssertEqual(title, "Document title 2021-05-19")
+        XCTAssertEqual(TitleFinder.title(from: "2018-12-23 Document title 2021-05-19"),
+                       "Document title 2021-05-19")
     }
 
     func testFirstDateWithinString() {
-        let title = TitleFinder.title(from: "Document title 2018-12-23 Further details")
-        XCTAssertEqual(title, "Document title 2018-12-23 Further details")
+        XCTAssertEqual(TitleFinder.title(from: "Document title 2018-12-23 Further details"),
+                       "Document title 2018-12-23 Further details")
     }
 
     func testDateOnlyStringYieldsTitle() {

--- a/core/FileawayCoreTests/TitleFinderTests.swift
+++ b/core/FileawayCoreTests/TitleFinderTests.swift
@@ -1,0 +1,87 @@
+// Copyright (c) 2018-2021 InSeven Limited
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import XCTest
+
+@testable import FileawayCore
+
+class TitleFinderTests: XCTestCase {
+
+    var calendar: Calendar = Calendar.gregorian
+
+    func date(_ year: Int, _ month: Int, _ day: Int) -> Date {
+        Calendar.gregorian.date(year, month, day)!
+    }
+
+    func testSingleDate() {
+        let title = TitleFinder.title(from: "2018-12-23 Document title")
+        XCTAssertEqual(title, "Document title")
+    }
+
+    func testSingleDateLeadingWhitespace() {
+        let title = TitleFinder.title(from: " 2018-12-23 Document title")
+        XCTAssertEqual(title, "Document title")
+    }
+
+    func testComplexDate() {
+        let title = TitleFinder.title(from: "Dec 23, 2018 Document title")
+        XCTAssertEqual(title, "Document title")
+    }
+
+    func testMultipleDates() {
+        let title = TitleFinder.title(from: "2018-12-23 Document title 2021-05-19")
+        XCTAssertEqual(title, "Document title 2021-05-19")
+    }
+
+    func testFirstDateWithinString() {
+        let title = TitleFinder.title(from: "Document title 2018-12-23 Further details")
+        XCTAssertEqual(title, "Document title 2018-12-23 Further details")
+    }
+
+    func testDateOnlyStringYieldsTitle() {
+        // Strings that contain just a date should return the full string.
+        XCTAssertEqual(TitleFinder.title(from: "Dec 28, 1982"),
+                       "Dec 28, 1982")
+        XCTAssertEqual(TitleFinder.title(from: "1982-12-28"),
+                       "1982-12-28")
+    }
+
+    func testStringWithoutDate() {
+        // Strings that contain just a date should return the full string.
+        XCTAssertEqual(TitleFinder.title(from: "Fromage"),
+                       "Fromage")
+    }
+
+    func testTrimming() {
+        XCTAssertEqual(TitleFinder.title(from: " 1982-12-28"),
+                       "1982-12-28")
+        XCTAssertEqual(TitleFinder.title(from: "1982-12-28 "),
+                       "1982-12-28")
+        XCTAssertEqual(TitleFinder.title(from: " 1982-12-28 "),
+                       "1982-12-28")
+        XCTAssertEqual(TitleFinder.title(from: " Date outside string 1982-12-28 Cheese"),
+                       "Date outside string 1982-12-28 Cheese")
+        XCTAssertEqual(TitleFinder.title(from: "Date outside string 1982-12-28 Cheese "),
+                       "Date outside string 1982-12-28 Cheese")
+    }
+
+    // TODO: Test Empty string
+
+}

--- a/core/FileawayCoreTests/TitleFinderTests.swift
+++ b/core/FileawayCoreTests/TitleFinderTests.swift
@@ -82,6 +82,15 @@ class TitleFinderTests: XCTestCase {
                        "Date outside string 1982-12-28 Cheese")
     }
 
-    // TODO: Test Empty string
+    func testEmptyString() {
+        XCTAssertEqual(TitleFinder.title(from: ""),
+                       "")
+        XCTAssertEqual(TitleFinder.title(from: " "),
+                       "")
+        XCTAssertEqual(TitleFinder.title(from: "\t"),
+                       "")
+        XCTAssertEqual(TitleFinder.title(from: "\n"),
+                       "")
+    }
 
 }


### PR DESCRIPTION
This change only strips dates from the beginning of filenames to try to prevent the title from becoming confusing when elements are missing. It also introduces new, more permissive, date detection (using NSDataDetector) which will hopefully prove a positive experience. Longer term, it’s quite possible that users may prefer more explicit control over the date formats that are recognised (e.g., always recognise ISO dates vs US dates, etc), but this can be added later if required.