### PR TITLE
fix: Correct display name for iCloud Drive and other special directories

### DIFF
--- a/core/FileawayCore.xcodeproj/project.pbxproj
+++ b/core/FileawayCore.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		D82D01142656FAC100FD2974 /* URL.swift in Sources */ = {isa = PBXBuildFile; fileRef = D82D01132656FAC100FD2974 /* URL.swift */; };
+		D82D01152656FAC100FD2974 /* URL.swift in Sources */ = {isa = PBXBuildFile; fileRef = D82D01132656FAC100FD2974 /* URL.swift */; };
 		D84E50B92654B02600496524 /* ComponentType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D84E50B82654B02600496524 /* ComponentType.swift */; };
 		D84E50BA2654B02600496524 /* ComponentType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D84E50B82654B02600496524 /* ComponentType.swift */; };
 		D84E50BC2654B05200496524 /* Component.swift in Sources */ = {isa = PBXBuildFile; fileRef = D84E50BB2654B05200496524 /* Component.swift */; };
@@ -68,6 +70,7 @@
 		D81F7C48216E3AA80070AAA0 /* FileawayCore.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FileawayCore.h; sourceTree = "<group>"; };
 		D81F7C49216E3AA80070AAA0 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D81F7C55216E3AA90070AAA0 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		D82D01132656FAC100FD2974 /* URL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URL.swift; sourceTree = "<group>"; };
 		D84E50B82654B02600496524 /* ComponentType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComponentType.swift; sourceTree = "<group>"; };
 		D84E50BB2654B05200496524 /* Component.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Component.swift; sourceTree = "<group>"; };
 		D84E50BE2654B07500496524 /* Variable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Variable.swift; sourceTree = "<group>"; };
@@ -207,6 +210,7 @@
 			isa = PBXGroup;
 			children = (
 				D898E66C2655848D005EA6DE /* Calendar.swift */,
+				D82D01132656FAC100FD2974 /* URL.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -433,6 +437,7 @@
 				D8D14DB7216E3E1400D6E1DF /* Configuration.swift in Sources */,
 				D88B86FD2656D8BF004F2F60 /* DateInstance.swift in Sources */,
 				D898E654265578EC005EA6DE /* FileInfo.swift in Sources */,
+				D82D01142656FAC100FD2974 /* URL.swift in Sources */,
 				D898E66D2655848D005EA6DE /* Calendar.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -464,6 +469,7 @@
 				D8BCA524216F08DF002A624D /* Configuration.swift in Sources */,
 				D88B86FE2656D8BF004F2F60 /* DateInstance.swift in Sources */,
 				D898E653265578EC005EA6DE /* FileInfo.swift in Sources */,
+				D82D01152656FAC100FD2974 /* URL.swift in Sources */,
 				D898E66E2655848D005EA6DE /* Calendar.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/core/FileawayCoreTests/Extensions/URL.swift
+++ b/core/FileawayCoreTests/Extensions/URL.swift
@@ -20,34 +20,10 @@
 
 import Foundation
 
-public class FileInfo: Identifiable, Hashable {
+public extension URL {
 
-    public var id: URL { url }
-    
-    public let url: URL
-    public let name: String
-    public var date: Date?
-    public let directoryUrl: URL
-
-    public var sortDate: Date {
-        date ?? Date.distantPast
-    }
-
-    public init(url: URL) {
-        self.url = url
-        let name = url.displayName.deletingPathExtension
-        self.date = DateFinder.dateInstances(from: name).map { $0.date }.first
-        let title = TitleFinder.title(from: name)
-        self.name = title.isEmpty ? name : title
-        self.directoryUrl = url.deletingLastPathComponent()
-    }
-
-    public static func == (lhs: FileInfo, rhs: FileInfo) -> Bool {
-        return lhs.url == rhs.url
-    }
-
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(url)
+    var displayName: String {
+        FileManager.default.displayName(atPath: self.path)
     }
 
 }

--- a/macos/Fileaway/Utilities/DirectoryObserver.swift
+++ b/macos/Fileaway/Utilities/DirectoryObserver.swift
@@ -40,7 +40,7 @@ class DirectoryObserver: ObservableObject, Identifiable, Hashable {
     var extensions = ["pdf"]
 
     var count: Int { self.files.count }
-    var name: String { url.lastPathComponent }
+    var name: String { url.displayName }
 
     @Published var searchResults: [FileInfo] = []
     var ruleSet: RuleSet

--- a/macos/Fileaway/Views/Wizard/TaskPage.swift
+++ b/macos/Fileaway/Views/Wizard/TaskPage.swift
@@ -69,7 +69,7 @@ struct TaskPage: View {
                             HStack {
                                 VStack(alignment: .leading, spacing: 4) {
                                     Text(rule.name)
-                                    Text(rule.rootUrl.lastPathComponent)
+                                    Text(rule.rootUrl.displayName)
                                         .foregroundColor(.secondary)
                                 }
                                 Spacer()


### PR DESCRIPTION
I was incorrectly using `lastPathComponent` as the display name for directories and files, even though `FileManager` has an explicit `displayName` which should be used for this.