### PR TITLE
feat: Sort by the file creation date if no date can be found in the filename

### DIFF
--- a/core/FileawayCore.xcodeproj/project.pbxproj
+++ b/core/FileawayCore.xcodeproj/project.pbxproj
@@ -11,6 +11,10 @@
 		D82D01152656FAC100FD2974 /* URL.swift in Sources */ = {isa = PBXBuildFile; fileRef = D82D01132656FAC100FD2974 /* URL.swift */; };
 		D82D0116265720FA00FD2974 /* Calendar.swift in Sources */ = {isa = PBXBuildFile; fileRef = D898E66C2655848D005EA6DE /* Calendar.swift */; };
 		D82D0117265720FA00FD2974 /* Calendar.swift in Sources */ = {isa = PBXBuildFile; fileRef = D898E66C2655848D005EA6DE /* Calendar.swift */; };
+		D82D01192657252B00FD2974 /* DateType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D82D01182657252B00FD2974 /* DateType.swift */; };
+		D82D011A2657252B00FD2974 /* DateType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D82D01182657252B00FD2974 /* DateType.swift */; };
+		D82D011C2657259F00FD2974 /* FileDate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D82D011B2657259F00FD2974 /* FileDate.swift */; };
+		D82D011D2657259F00FD2974 /* FileDate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D82D011B2657259F00FD2974 /* FileDate.swift */; };
 		D84E50B92654B02600496524 /* ComponentType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D84E50B82654B02600496524 /* ComponentType.swift */; };
 		D84E50BA2654B02600496524 /* ComponentType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D84E50B82654B02600496524 /* ComponentType.swift */; };
 		D84E50BC2654B05200496524 /* Component.swift in Sources */ = {isa = PBXBuildFile; fileRef = D84E50BB2654B05200496524 /* Component.swift */; };
@@ -71,6 +75,8 @@
 		D81F7C49216E3AA80070AAA0 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D81F7C55216E3AA90070AAA0 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D82D01132656FAC100FD2974 /* URL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URL.swift; sourceTree = "<group>"; };
+		D82D01182657252B00FD2974 /* DateType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateType.swift; sourceTree = "<group>"; };
+		D82D011B2657259F00FD2974 /* FileDate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileDate.swift; sourceTree = "<group>"; };
 		D84E50B82654B02600496524 /* ComponentType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComponentType.swift; sourceTree = "<group>"; };
 		D84E50BB2654B05200496524 /* Component.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Component.swift; sourceTree = "<group>"; };
 		D84E50BE2654B07500496524 /* Variable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Variable.swift; sourceTree = "<group>"; };
@@ -164,7 +170,9 @@
 				D876A3BC26548C61006D19FB /* BackChannel.swift */,
 				D898E65B26557AC3005EA6DE /* DateFinder.swift */,
 				D88B86FC2656D8BF004F2F60 /* DateInstance.swift */,
+				D82D01182657252B00FD2974 /* DateType.swift */,
 				D81F7C48216E3AA80070AAA0 /* FileawayCore.h */,
+				D82D011B2657259F00FD2974 /* FileDate.swift */,
 				D898E652265578EC005EA6DE /* FileInfo.swift */,
 				D81F7C49216E3AA80070AAA0 /* Info.plist */,
 				D8D14D58216E3BAE00D6E1DF /* Manager.swift */,
@@ -428,10 +436,12 @@
 				D84E50BF2654B07500496524 /* Variable.swift in Sources */,
 				D84E50BC2654B05200496524 /* Component.swift in Sources */,
 				D8D14DB9216E3E1400D6E1DF /* Manager.swift in Sources */,
+				D82D011C2657259F00FD2974 /* FileDate.swift in Sources */,
 				D898E65C26557AC3005EA6DE /* DateFinder.swift in Sources */,
 				D84E50B92654B02600496524 /* ComponentType.swift in Sources */,
 				D84E50C22654B0B000496524 /* VariableType.swift in Sources */,
 				D898E65F26557AFD005EA6DE /* TitleFinder.swift in Sources */,
+				D82D01192657252B00FD2974 /* DateType.swift in Sources */,
 				D876A3BE26548C61006D19FB /* BackChannel.swift in Sources */,
 				D84E50C52654B0DE00496524 /* Task.swift in Sources */,
 				D8D14DB7216E3E1400D6E1DF /* Configuration.swift in Sources */,
@@ -460,10 +470,12 @@
 				D84E50C02654B07500496524 /* Variable.swift in Sources */,
 				D84E50BD2654B05200496524 /* Component.swift in Sources */,
 				D8BCA526216F08DF002A624D /* Manager.swift in Sources */,
+				D82D011D2657259F00FD2974 /* FileDate.swift in Sources */,
 				D898E65D26557AC3005EA6DE /* DateFinder.swift in Sources */,
 				D84E50BA2654B02600496524 /* ComponentType.swift in Sources */,
 				D84E50C32654B0B000496524 /* VariableType.swift in Sources */,
 				D898E66026557AFD005EA6DE /* TitleFinder.swift in Sources */,
+				D82D011A2657252B00FD2974 /* DateType.swift in Sources */,
 				D876A3BD26548C61006D19FB /* BackChannel.swift in Sources */,
 				D84E50C62654B0DE00496524 /* Task.swift in Sources */,
 				D8BCA524216F08DF002A624D /* Configuration.swift in Sources */,

--- a/core/FileawayCore/DateFinder.swift
+++ b/core/FileawayCore/DateFinder.swift
@@ -22,12 +22,6 @@ import Foundation
 
 class DateFinder {
 
-    // TODO: Revisit the caching in DateFinder and TitleFinder #160
-    //       https://github.com/jbmorley/fileaway/issues/160
-    static var cache: NSCache<NSString, NSArray> = {
-        return NSCache()
-    }()
-
     static var dateFormatter: DateFormatter = {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy-MM-dd"
@@ -35,13 +29,6 @@ class DateFinder {
     }()
 
     static func dateInstances(from string: String) -> Array<DateInstance> {
-
-        // Check the cache.
-        if let dates = Self.cache.object(forKey: string as NSString) as? Array<DateInstance> {
-            return dates
-        }
-
-        // Find the dates.
         let types: NSTextCheckingResult.CheckingType = [.date]
         let detector = try! NSDataDetector(types: types.rawValue)
         let matches = detector.matches(in: string, options: [], range: NSRange(location: 0, length: string.count))
@@ -51,10 +38,6 @@ class DateFinder {
             }
             return DateInstance(date: date, range: textCheckingResult.range)
         }
-
-        // Update the cache.
-        Self.cache.setObject(dateInstances as NSArray, forKey: string as NSString)
-
         return dateInstances
     }
 

--- a/core/FileawayCore/DateType.swift
+++ b/core/FileawayCore/DateType.swift
@@ -20,29 +20,10 @@
 
 import Foundation
 
-class TitleFinder {
+public enum DateType {
 
-    static var dateFormatter: DateFormatter = {
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy-MM-dd"
-        return dateFormatter
-    }()
+    case unknown
+    case filename
+    case creation
 
-    static func stringRemovingFirstDate(from string: String) -> String {
-        guard let dateInstance = DateFinder.dateInstances(from: string).first,
-              dateInstance.range.location == 0 else {
-            return string
-        }
-        let index = string.index(string.startIndex, offsetBy: dateInstance.range.length)
-        let title = String(string[index...])
-        guard title.count > 0 else {
-            return string
-        }
-        return title
-    }
-
-    static func title(from string: String) -> String {
-        return stringRemovingFirstDate(from: string.trimmingCharacters(in: .whitespacesAndNewlines))
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-    }
 }

--- a/core/FileawayCore/FileDate.swift
+++ b/core/FileawayCore/FileDate.swift
@@ -20,29 +20,9 @@
 
 import Foundation
 
-class TitleFinder {
+public struct FileDate {
 
-    static var dateFormatter: DateFormatter = {
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy-MM-dd"
-        return dateFormatter
-    }()
+    public let date: Date
+    public let type: DateType
 
-    static func stringRemovingFirstDate(from string: String) -> String {
-        guard let dateInstance = DateFinder.dateInstances(from: string).first,
-              dateInstance.range.location == 0 else {
-            return string
-        }
-        let index = string.index(string.startIndex, offsetBy: dateInstance.range.length)
-        let title = String(string[index...])
-        guard title.count > 0 else {
-            return string
-        }
-        return title
-    }
-
-    static func title(from string: String) -> String {
-        return stringRemovingFirstDate(from: string.trimmingCharacters(in: .whitespacesAndNewlines))
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-    }
 }

--- a/macos/Fileaway/Views/DateView.swift
+++ b/macos/Fileaway/Views/DateView.swift
@@ -20,6 +20,8 @@
 
 import SwiftUI
 
+import FileawayCore
+
 struct DateView: View {
 
     static var dateFormatter: DateFormatter = {
@@ -28,9 +30,27 @@ struct DateView: View {
         return dateFormatter
     }()
 
-    let date: Date
+    let date: FileDate
+
+    var description: String {
+        switch date.type {
+        case .creation:
+            return "File creation date"
+        case .filename:
+            return "Date found in filename"
+        case .unknown:
+            return "Unknown"
+        }
+    }
 
     var body: some View {
-        Text(Self.dateFormatter.string(from: date))
+        switch date.type {
+        case .unknown:
+            EmptyView()
+        default:
+            Text(Self.dateFormatter.string(from: date.date))
+                .help(description)
+        }
     }
+
 }


### PR DESCRIPTION
This change also moves caching into the DirectoryObserver and out of the DateFinder and TitleFinder utilities to better match the lifecycle of the data and sure up thread safety.

In order to better help users understand where the dates are coming from, it adds a tooltip to the date element in the list.