### PR TITLE
ci: Ensure TRY_RELEASE doesn't need to be defined for local builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,6 @@ export FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD=
 
 # GitHub (only required if publishing releases locally)
 export GITHUB_TOKEN=
-
-# Release
-export TRY_RELEASE=false
 ```
 
 You can generate your GitHub authorization key (for `CERTIFICATE_REPOSITORY_AUTHORIZATION_KEY`) as follows:

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -46,7 +46,7 @@ PATH=$PATH:$BUILD_TOOLS_DIRECTORY
 # Process the command line arguments.
 POSITIONAL=()
 NOTARIZE=${NOTARIZE:-false}
-RELEASE=false
+RELEASE=${TRY_RELEASE:-false}
 while [[ $# -gt 0 ]]
 do
     key="$1"
@@ -178,7 +178,7 @@ zip -r "Artifacts.zip" "."
 popd
 
 # Attempt to create a version tag and publish a GitHub release; fails quietly if there's no new release.
-if $RELEASE || $TRY_RELEASE ; then
+if $RELEASE ; then
     changes \
         --scope macOS \
         release \


### PR DESCRIPTION
Previously, even though it was ignored, the `TRY_RELEASE` environment variable needed to be defined as otherwise it caused an unbound variable error.